### PR TITLE
Fix deprecations for yml

### DIFF
--- a/Resources/config/web_push.yml
+++ b/Resources/config/web_push.yml
@@ -4,6 +4,6 @@ parameters:
 services:
   minishlink_web_push:
     class: %minishlink_web_push.class%
-    arguments: [%minishlink_web_push.api_keys%, %minishlink_web_push.default_options%, %minishlink_web_push.timeout%, null]
+    arguments: ['%minishlink_web_push.api_keys%', '%minishlink_web_push.default_options%', '%minishlink_web_push.timeout%', null]
     calls:
       - [setAutomaticPadding, ['%minishlink_web_push.automatic_padding%']]


### PR DESCRIPTION
Symfony throws this deprecation error:
"Not quoting the scalar "%minishlink_web_push.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0"
