### PR TITLE
upgrade dependencies and add first test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.vscode/

--- a/DependencyInjection/MinishlinkWebPushExtension.php
+++ b/DependencyInjection/MinishlinkWebPushExtension.php
@@ -19,7 +19,7 @@ class MinishlinkWebPushExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('web_push.yml');
 
         $defaultOptions = array(
@@ -30,7 +30,9 @@ class MinishlinkWebPushExtension extends Extension
 
         if (array_key_exists('VAPID', $config)) {
             $auth = array_merge($config['api_keys'], array('VAPID' => $config['VAPID']));
-        } else $auth = $config['api_keys'];
+        } else {
+            $auth = $config['api_keys'];
+        }
 
         $container->setParameter('minishlink_web_push.auth', $auth);
         $container->setParameter('minishlink_web_push.default_options', $defaultOptions);

--- a/Tests/DependencyInjection/MinishlinkWebPushExtensionTest.php
+++ b/Tests/DependencyInjection/MinishlinkWebPushExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Minishlink\WebPushBundle\DependencyInjection;
+
+use Minishlink\WebPush\WebPush;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Minishlink\Bundle\WebPushBundle\DependencyInjection\MinishlinkWebPushExtension;
+
+/**
+ * Test for the WebPush Extension
+ * 
+ * @author Tim Bernhard <tim@bernhard-webstudio.ch>
+ */
+class MinishlinkWebPushExtensionTest extends AbstractExtensionTestCase
+{
+
+    protected function getContainerExtensions() {
+        return array(
+            new MinishlinkWebPushExtension()
+        );
+    }
+
+    public function testWithoutConfiguration() {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('minishlink_web_push.auth');
+        $this->assertContainerBuilderHasParameter('minishlink_web_push.default_options');
+        $this->assertContainerBuilderHasParameter('minishlink_web_push.timeout');
+        $this->assertContainerBuilderHasParameter('minishlink_web_push.automatic_padding');
+        $this->assertContainerBuilderHasService('minishlink_web_push');
+        $this->assertInstanceOf(WebPush::class, $this->container->get('minishlink_web_push'));
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
   "name": "minishlink/web-push-bundle",
   "type": "symfony-bundle",
   "description": "Symfony Bundle around the WebPush library",
-  "keywords": ["push", "notifications", "web", "WebPush"],
+  "keywords": [
+    "push",
+    "notifications",
+    "web",
+    "WebPush"
+  ],
   "homepage": "https://github.com/minishlink/web-push-bundle",
   "license": "MIT",
   "authors": [
@@ -13,15 +18,20 @@
     }
   ],
   "require": {
-    "minishlink/web-push": "~2.0.0"
+    "php": "^7.1",
+    "minishlink/web-push": "^4.0.0"
   },
   "require-dev": {
-    "symfony/framework-bundle": "^2.7"
+    "symfony/framework-bundle": "^3.0|^4.0",
+    "phpunit/phpunit": "^7.1",
+    "symfony/phpunit-bridge": "^4.0",
+    "matthiasnoback/symfony-dependency-injection-test": "^3.0"
   },
   "target-dir": "Minishlink/Bundle/WebPushBundle",
   "autoload": {
     "psr-0": {
-      "Minishlink\\Bundle\\WebPushBundle": ""
+      "Minishlink\\Bundle\\WebPushBundle": "",
+      "Tests\\Minishlink\\WebPushBundle": "Tests"
     }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php">
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony WebPushBundle Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
As to resolve #9 , this is my suggestion. It jumps straight up to v4 of the child repo and equally requires PHP >= 7.1 from now on. I allowed myself to add a first unit test, although I quickly realized that it is not really necessary like this yet. 
Probably, it would be a good idea to test multiple configurations, with the configurations as in the tests of the web-push library, but for now, as I do not fear any breaking changes in the order of the arguments, I suggest to postpone that.