### PR TITLE
Make Symfony 7 compatible

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('minishlink_web_push');
 


### PR DESCRIPTION
Hi, this bundle is not compatible with Symfony 7.0 due to a missing return type declaration:

When compiling the container it throws a Fatal error:

![image](https://github.com/Minishlink/web-push-bundle/assets/1941064/f7e7cd93-9d97-43fc-867e-2eb98d0fdcbd)


See this Symfony [ blogpost ](https://symfony.com/blog/symfony-7-0-type-declarations) 

Btw, thanks for your free time dedication.