### PR TITLE
Add new alias to 'minishlink_web_push' service to be used with autowiring

### DIFF
--- a/Resources/config/web_push.yml
+++ b/Resources/config/web_push.yml
@@ -7,3 +7,5 @@ services:
     arguments: ['%minishlink_web_push.auth%', '%minishlink_web_push.default_options%', '%minishlink_web_push.timeout%', []]
     calls:
       - [setAutomaticPadding, ['%minishlink_web_push.automatic_padding%']]
+  Minishlink\WebPush\WebPush:
+      alias: minishlink_web_push

--- a/Tests/DependencyInjection/MinishlinkWebPushExtensionTest.php
+++ b/Tests/DependencyInjection/MinishlinkWebPushExtensionTest.php
@@ -16,7 +16,8 @@ use Minishlink\Bundle\WebPushBundle\DependencyInjection\MinishlinkWebPushExtensi
 class MinishlinkWebPushExtensionTest extends AbstractExtensionTestCase
 {
 
-    protected function getContainerExtensions() {
+    protected function getContainerExtensions(): array
+    {
         return array(
             new MinishlinkWebPushExtension()
         );
@@ -30,7 +31,9 @@ class MinishlinkWebPushExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('minishlink_web_push.timeout');
         $this->assertContainerBuilderHasParameter('minishlink_web_push.automatic_padding');
         $this->assertContainerBuilderHasService('minishlink_web_push');
+        $this->assertContainerBuilderHasService('Minishlink\WebPush\WebPush');
         $this->assertInstanceOf(WebPush::class, $this->container->get('minishlink_web_push'));
+        $this->assertInstanceOf(WebPush::class, $this->container->get('Minishlink\WebPush\WebPush'));
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   },
   "require-dev": {
     "symfony/framework-bundle": "^4.2|^5.0",
-    "phpunit/phpunit": "^7.1",
+    "phpunit/phpunit": "^9.3.0",
     "symfony/phpunit-bridge": "^5.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^3.0"
+    "matthiasnoback/symfony-dependency-injection-test": "^4.2.1"
   },
   "target-dir": "Minishlink/Bundle/WebPushBundle",
   "autoload": {


### PR DESCRIPTION
Hi, sorry for the delay.... :/ This PR is related to this comment -> https://github.com/Minishlink/web-push-bundle/issues/25#issuecomment-1937483286

This commit fixes a problem when a client tries to use the service with the Symfony autowiring, I mean, injecting the service class directly as a constructor argument.

A new FQDN service is created as an alias of the existing **minishlink_web_push** service.

I've bump some dev dependencies just to be able to execute the tests. IMHO if the bundle is compatible with PHP versions ^7.2 || ^8.0 , it's coherent (at least for me) that the test suite can be executed with modern PHP versions, I tried to bump the versions as lower as possible, but if you prefer that I don't update the dependencies, it's not a problem.