### PR TITLE
Add return type declaration of load method

### DIFF
--- a/DependencyInjection/MinishlinkWebPushExtension.php
+++ b/DependencyInjection/MinishlinkWebPushExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class MinishlinkWebPushExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
Hi, trying to remove all my deprecation messages in order to upgrade my application to Symfony , it shows me this message:

`Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Minishlink\Bundle\WebPushBundle\DependencyInjection\MinishlinkWebPushExtension" now to avoid errors or add an explicit @return annotation to suppress this message.`

 it's safer to add  the void return type to the load method