### PR TITLE
Fix deprecation for HttpKernel\DependencyInjection\Extension class

### DIFF
--- a/DependencyInjection/MinishlinkWebPushExtension.php
+++ b/DependencyInjection/MinishlinkWebPushExtension.php
@@ -4,8 +4,8 @@ namespace Minishlink\Bundle\WebPushBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * MinishlinkWebPushExtension.


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. 

Symfony PR https://github.com/symfony/symfony/pull/53801